### PR TITLE
[bug] module naming matters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ fn map_market_listed(
 }
 
 #[substreams::handlers::store]
-fn store_mint_event(mint_list: compound::MintList, output: store::StoreSet) {
+fn store_mint(mint_list: compound::MintList, output: store::StoreSet) {
     for mint in mint_list.mint_list {
         output.set(
             0,

--- a/substreams.yaml
+++ b/substreams.yaml
@@ -82,7 +82,7 @@ modules:
       - store: store_oracle
       - store: store_token
 
-  - name: store_mint_event
+  - name: store_mint
     kind: store
     updatePolicy: set
     valueType: proto:compound.v1.Mint


### PR DESCRIPTION
To reproduce, run the below command. Note `"key": "mint:count:18023"` appears while it is irrelevant

```
$ substreams run -e api-dev.streamingfast.io:443 substreams.yaml store_mint --start-block 7710671 --stop-block +1000 -o json
{
  "@module": "store_mint",
  "@block": 7710833,
  "@deltas": [
    {
      "op": "CREATE",
      "ordinal": 0,
      "key": "mint:count:18023",
      "old": null,
      "new": {
        "@error": "error unmarshalling message into compound.v1.Mint: unexpected EOF\n",
        "@str": "\"1\"",
        "@bytes": "MQ=="
      }
    }
  ]
}
{
  "@module": "store_mint",
  "@block": 7710847,
  "@deltas": [
    {
      "op": "UPDATE",
      "ordinal": 0,
      "key": "mint:count:18023",
      "old": {
        "@error": "error unmarshalling message into compound.v1.Mint: unexpected EOF\n",
        "@str": "\"1\"",
        "@bytes": "MQ=="
      },
      "new": {
        "@error": "error unmarshalling message into compound.v1.Mint: unexpected EOF\n",
        "@str": "\"2\"",
        "@bytes": "Mg=="
      }
    }
  ]
}
{
  "@module": "store_mint",
  "@block": 7710960,
  "@deltas": [
    {
      "op": "UPDATE",
      "ordinal": 0,
      "key": "mint:count:18023",
      "old": {
        "@error": "error unmarshalling message into compound.v1.Mint: unexpected EOF\n",
        "@str": "\"2\"",
        "@bytes": "Mg=="
      },
      "new": {
        "@error": "error unmarshalling message into compound.v1.Mint: unexpected EOF\n",
        "@str": "\"3\"",
        "@bytes": "Mw=="
      }
    },
    {
      "op": "UPDATE",
      "ordinal": 0,
      "key": "mint:count:18023",
      "old": {
        "@error": "error unmarshalling message into compound.v1.Mint: unexpected EOF\n",
        "@str": "\"3\"",
        "@bytes": "Mw=="
      },
      "new": {
        "@error": "error unmarshalling message into compound.v1.Mint: proto: bad wiretype\n",
        "@str": "\"4\"",
        "@bytes": "NA=="
      }
    }
  ]
}
^C
```